### PR TITLE
feat: adding save system for score

### DIFF
--- a/Assets/MainMenu.cs
+++ b/Assets/MainMenu.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using TMPro;
 
 public class MainMenu : MonoBehaviour
 {
@@ -8,6 +9,64 @@ public class MainMenu : MonoBehaviour
 
     [Tooltip("Fallback build index to load if the scene name is empty or not set in Inspector.")]
     public int levelSelectBuildIndex = 1;
+
+    [Header("High Score Display")]
+    [Tooltip("Optional TextMeshProUGUI component to display the high score. Leave empty if not needed.")]
+    public TextMeshProUGUI highScoreText;
+
+    [Tooltip("Optional Text component to display the high score. Leave empty if not needed.")]
+    public UnityEngine.UI.Text highScoreTextLegacy;
+
+    [Tooltip("Prefix text for high score display (e.g., 'Best Time: ').")]
+    public string highScorePrefix = "Best Time: ";
+
+    private void Start()
+    {
+        // Ensure ProgressManager exists and loads progress
+        if (ProgressManager.Instance == null)
+        {
+            GameObject progressManagerObj = new GameObject("ProgressManager");
+            progressManagerObj.AddComponent<ProgressManager>();
+        }
+
+        // Display high score
+        UpdateHighScoreDisplay();
+    }
+
+    /// <summary>
+    /// Updates the high score display with the saved high score
+    /// </summary>
+    private void UpdateHighScoreDisplay()
+    {
+        if (ProgressManager.Instance == null)
+        {
+            return;
+        }
+
+        float highScore = ProgressManager.Instance.GetHighScore();
+        string displayText = highScorePrefix;
+
+        if (highScore > 0)
+        {
+            displayText += ProgressManager.FormatTime(highScore);
+        }
+        else
+        {
+            displayText += "N/A";
+        }
+
+        // Update TextMeshProUGUI if assigned
+        if (highScoreText != null)
+        {
+            highScoreText.text = displayText;
+        }
+
+        // Update legacy Text component if assigned
+        if (highScoreTextLegacy != null)
+        {
+            highScoreTextLegacy.text = displayText;
+        }
+    }
 
     // Called by the Play button on the main menu. By default it will open the Level Select scene.
     public void PlayGame()

--- a/Assets/Scenes/Level2.unity
+++ b/Assets/Scenes/Level2.unity
@@ -1155,6 +1155,50 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &197267765
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 197267767}
+  - component: {fileID: 197267766}
+  m_Layer: 0
+  m_Name: LevelTimer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &197267766
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 197267765}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3e41c49b980cf164789490f753b95d94, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::LevelTimer
+--- !u!4 &197267767
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 197267765}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 2.79642, y: 0.22831, z: 3.65557}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &203302963 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8773908460497380625, guid: 76d20325ed3ec99428280f775a27e0fe, type: 3}
@@ -11519,3 +11563,4 @@ SceneRoots:
   - {fileID: 1029637633}
   - {fileID: 1474246562}
   - {fileID: 281062598}
+  - {fileID: 197267767}

--- a/Assets/Scenes/Level3.unity
+++ b/Assets/Scenes/Level3.unity
@@ -7394,6 +7394,50 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 1258589967228540330, guid: 63f7e3a5ea486a9438b4cd3142c7dc92, type: 3}
   m_PrefabInstance: {fileID: 1768946727}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1276487437
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1276487439}
+  - component: {fileID: 1276487438}
+  m_Layer: 0
+  m_Name: LevelTimer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1276487438
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1276487437}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3e41c49b980cf164789490f753b95d94, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::LevelTimer
+--- !u!4 &1276487439
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1276487437}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 2.79642, y: 0.22831, z: 3.65557}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1279477527
 GameObject:
   m_ObjectHideFlags: 0
@@ -11655,3 +11699,4 @@ SceneRoots:
   - {fileID: 275959492}
   - {fileID: 1861152423}
   - {fileID: 1737132268}
+  - {fileID: 1276487439}

--- a/Assets/Scenes/Levels.unity
+++ b/Assets/Scenes/Levels.unity
@@ -474,6 +474,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 392069755}
+  - {fileID: 284776832}
   m_Father: {fileID: 1790854762}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -575,6 +576,142 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 270646022}
   m_CullTransparentMesh: 1
+--- !u!1 &284776831
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 284776832}
+  - component: {fileID: 284776833}
+  - component: {fileID: 284776834}
+  m_Layer: 5
+  m_Name: timetext
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &284776832
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 284776831}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 270646023}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 1, y: -40.40001}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &284776833
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 284776831}
+  m_CullTransparentMesh: 1
+--- !u!114 &284776834
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 284776831}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: New Text
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 20
+  m_fontSizeBase: 20
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 1.1872635, w: 29.729351}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &351549369
 GameObject:
   m_ObjectHideFlags: 0
@@ -607,6 +744,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 925097686}
+  - {fileID: 880534714}
   m_Father: {fileID: 1790854762}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -844,6 +982,142 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 392069754}
   m_CullTransparentMesh: 1
+--- !u!1 &456846501
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 456846504}
+  - component: {fileID: 456846503}
+  - component: {fileID: 456846502}
+  m_Layer: 5
+  m_Name: timetext
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &456846502
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 456846501}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: New Text
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 20
+  m_fontSizeBase: 20
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 1.1872635, w: 29.729351}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &456846503
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 456846501}
+  m_CullTransparentMesh: 1
+--- !u!224 &456846504
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 456846501}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1667765124}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.9, y: -39.7}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &483755713
 GameObject:
   m_ObjectHideFlags: 0
@@ -1083,6 +1357,142 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1 &880534713
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 880534714}
+  - component: {fileID: 880534715}
+  - component: {fileID: 880534716}
+  m_Layer: 5
+  m_Name: timetext
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &880534714
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 880534713}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 351549370}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -40.4}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &880534715
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 880534713}
+  m_CullTransparentMesh: 1
+--- !u!114 &880534716
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 880534713}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: New Text
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 20
+  m_fontSizeBase: 20
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 1.1872635, w: 29.729351}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &910424799
 GameObject:
   m_ObjectHideFlags: 0
@@ -1943,6 +2353,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 217410070}
+  - {fileID: 456846504}
   m_Father: {fileID: 1790854762}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -2425,6 +2836,71 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2002401807}
   m_CullTransparentMesh: 1
+--- !u!1 &2069915923
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2069915925}
+  - component: {fileID: 2069915924}
+  m_Layer: 0
+  m_Name: LevelProgressUI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2069915924
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2069915923}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 994676ae1c254c340bfb5880cfeff41d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::LevelProgressUI
+  levelButtons:
+  - levelButton: {fileID: 351549369}
+    levelIndex: 1
+    timeText: {fileID: 0}
+    timeTextTMP: {fileID: 880534716}
+    lockedText: {fileID: 0}
+    lockedTextTMP: {fileID: 0}
+  - levelButton: {fileID: 270646022}
+    levelIndex: 4
+    timeText: {fileID: 0}
+    timeTextTMP: {fileID: 284776834}
+    lockedText: {fileID: 0}
+    lockedTextTMP: {fileID: 0}
+  - levelButton: {fileID: 1667765123}
+    levelIndex: 5
+    timeText: {fileID: 0}
+    timeTextTMP: {fileID: 456846502}
+    lockedText: {fileID: 0}
+    lockedTextTMP: {fileID: 0}
+  lockedText: LOCKED
+  noTimeText: Not Completed
+--- !u!4 &2069915925
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2069915923}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 28.89435, y: 0, z: 728.74304}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -2436,3 +2912,4 @@ SceneRoots:
   - {fileID: 8459805}
   - {fileID: 812049369}
   - {fileID: 1770845570}
+  - {fileID: 2069915925}

--- a/Assets/Scenes/MainGameScene.unity
+++ b/Assets/Scenes/MainGameScene.unity
@@ -4299,6 +4299,50 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4642166958362574715, guid: e50cb583ba131ef428f99c349fde0fe3, type: 3}
   m_PrefabInstance: {fileID: 560381930}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &572666457
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 572666459}
+  - component: {fileID: 572666458}
+  m_Layer: 0
+  m_Name: LevelTimer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &572666458
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 572666457}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3e41c49b980cf164789490f753b95d94, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::LevelTimer
+--- !u!4 &572666459
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 572666457}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 2.79642, y: 0.22831, z: 3.65557}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &607063521
 GameObject:
   m_ObjectHideFlags: 0
@@ -18872,3 +18916,4 @@ SceneRoots:
   - {fileID: 1521189761}
   - {fileID: 261971885}
   - {fileID: 1527068274}
+  - {fileID: 572666459}

--- a/Assets/Scenes/MainMenu.unity
+++ b/Assets/Scenes/MainMenu.unity
@@ -442,17 +442,23 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Version: 3
   m_UsePipelineSettings: 1
   m_AdditionalLightsShadowResolutionTier: 2
-  m_LightLayerMask: 1
-  m_RenderingLayers: 1
   m_CustomShadowLayers: 0
-  m_ShadowLayerMask: 1
-  m_ShadowRenderingLayers: 1
   m_LightCookieSize: {x: 1, y: 1}
   m_LightCookieOffset: {x: 0, y: 0}
   m_SoftShadowQuality: 0
+  m_RenderingLayersMask:
+    serializedVersion: 0
+    m_Bits: 1
+  m_ShadowRenderingLayersMask:
+    serializedVersion: 0
+    m_Bits: 1
+  m_Version: 4
+  m_LightLayerMask: 1
+  m_ShadowLayerMask: 1
+  m_RenderingLayers: 1
+  m_ShadowRenderingLayers: 1
 --- !u!1 &894188157
 GameObject:
   m_ObjectHideFlags: 0
@@ -484,6 +490,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   levelSelectSceneName: Levels
   levelSelectBuildIndex: 3
+  highScoreText: {fileID: 1516356445}
+  highScoreTextLegacy: {fileID: 0}
+  highScorePrefix: 'Best Time: '
 --- !u!4 &894188159
 Transform:
   m_ObjectHideFlags: 0
@@ -629,7 +638,6 @@ MonoBehaviour:
   m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
   m_RequiresDepthTexture: 0
   m_RequiresColorTexture: 0
-  m_Version: 2
   m_TaaSettings:
     m_Quality: 3
     m_FrameInfluence: 0.1
@@ -637,6 +645,7 @@ MonoBehaviour:
     m_MipBias: 0
     m_VarianceClampScale: 0.9
     m_ContrastAdaptiveSharpening: 0
+  m_Version: 2
 --- !u!114 &944479919
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -651,6 +660,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   levelSelectSceneName: Levels
   levelSelectBuildIndex: 1
+  highScoreText: {fileID: 0}
+  highScoreTextLegacy: {fileID: 0}
+  highScorePrefix: 'Best Time: '
 --- !u!1 &1140263439
 GameObject:
   m_ObjectHideFlags: 0
@@ -786,6 +798,244 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1140263439}
+  m_CullTransparentMesh: 1
+--- !u!1 &1237130506
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1237130510}
+  - component: {fileID: 1237130509}
+  - component: {fileID: 1237130508}
+  - component: {fileID: 1237130507}
+  m_Layer: 5
+  m_Name: Scoreprogress
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1237130507
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1237130506}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.GraphicRaycaster
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &1237130508
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1237130506}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.CanvasScaler
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!223 &1237130509
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1237130506}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &1237130510
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1237130506}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1516356444}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!1 &1516356443
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1516356444}
+  - component: {fileID: 1516356446}
+  - component: {fileID: 1516356445}
+  m_Layer: 5
+  m_Name: highscoretext
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1516356444
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1516356443}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1237130510}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -201, y: 144}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1516356445
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1516356443}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: New Text
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 24
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1516356446
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1516356443}
   m_CullTransparentMesh: 1
 --- !u!1 &1524921283
 GameObject:
@@ -1309,6 +1559,50 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1972332941}
   m_CullTransparentMesh: 1
+--- !u!1 &2076118858
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2076118859}
+  - component: {fileID: 2076118860}
+  m_Layer: 0
+  m_Name: ProgressManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2076118859
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2076118858}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 10.38791, y: 0.8481, z: 13.57938}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2076118860
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2076118858}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3fd64221e127e2649a725f064d77406a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::ProgressManager
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -1318,3 +1612,5 @@ SceneRoots:
   - {fileID: 1920255394}
   - {fileID: 1668237881}
   - {fileID: 894188159}
+  - {fileID: 2076118859}
+  - {fileID: 1237130510}

--- a/Assets/Scripts/EndLineTrigger.cs
+++ b/Assets/Scripts/EndLineTrigger.cs
@@ -10,6 +10,32 @@ public class EndLineTrigger : MonoBehaviour
     {
         if(other.CompareTag("Player"))
         {
+            // Get current level index
+            int currentLevelIndex = SceneManager.GetActiveScene().buildIndex;
+            
+            // Find and stop the level timer
+            LevelTimer timer = FindObjectOfType<LevelTimer>();
+            if (timer != null)
+            {
+                float completionTime = timer.StopTimer();
+                
+                // Save the completion time if ProgressManager exists
+                if (ProgressManager.Instance != null)
+                {
+                    ProgressManager.Instance.SaveLevelTime(currentLevelIndex, completionTime);
+                    
+                    // Unlock the next level
+                    if (sceneIndexToLoad > 0)
+                    {
+                        ProgressManager.Instance.UnlockLevel(sceneIndexToLoad);
+                    }
+                }
+            }
+            else
+            {
+                Debug.LogWarning("LevelTimer not found! Completion time will not be saved.");
+            }
+
             Debug.Log("Level Completed! Loading Scene " + sceneIndexToLoad);
             SceneManager.LoadScene(sceneIndexToLoad); // Load scene by index
         }

--- a/Assets/Scripts/LevelProgressUI.cs
+++ b/Assets/Scripts/LevelProgressUI.cs
@@ -1,0 +1,167 @@
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+
+/// <summary>
+/// Displays level progress information (best times, unlocked status) on the Levels scene.
+/// Attach this to a GameObject in the Levels scene and assign level buttons and text components.
+/// </summary>
+public class LevelProgressUI : MonoBehaviour
+{
+    [System.Serializable]
+    public class LevelButtonData
+    {
+        [Tooltip("The level button GameObject")]
+        public GameObject levelButton;
+        
+        [Tooltip("The level build index (scene index)")]
+        public int levelIndex;
+        
+        [Tooltip("Optional: Text component to display best time. If null, will search for Text or TextMeshProUGUI in children.")]
+        public Text timeText;
+        
+        [Tooltip("Optional: TextMeshProUGUI component to display best time. If null, will search for Text or TextMeshProUGUI in children.")]
+        public TextMeshProUGUI timeTextTMP;
+        
+        [Tooltip("Optional: Text component to display 'Locked' status. If null, will search for Text or TextMeshProUGUI in children.")]
+        public Text lockedText;
+        
+        [Tooltip("Optional: TextMeshProUGUI component to display 'Locked' status. If null, will search for Text or TextMeshProUGUI in children.")]
+        public TextMeshProUGUI lockedTextTMP;
+    }
+
+    [Header("Level Buttons Configuration")]
+    [Tooltip("Array of level button data. Configure each level's button and display components.")]
+    public LevelButtonData[] levelButtons;
+
+    [Header("UI Settings")]
+    [Tooltip("Text to show when level is locked")]
+    public string lockedText = "LOCKED";
+    
+    [Tooltip("Text to show when level has no best time yet")]
+    public string noTimeText = "Not Completed";
+
+    private void Start()
+    {
+        // Ensure ProgressManager exists
+        if (ProgressManager.Instance == null)
+        {
+            GameObject progressManagerObj = new GameObject("ProgressManager");
+            progressManagerObj.AddComponent<ProgressManager>();
+        }
+
+        UpdateLevelDisplays();
+    }
+
+    /// <summary>
+    /// Updates all level button displays with best times and unlock status
+    /// </summary>
+    public void UpdateLevelDisplays()
+    {
+        if (levelButtons == null || levelButtons.Length == 0)
+        {
+            Debug.LogWarning("LevelProgressUI: No level buttons configured!");
+            return;
+        }
+
+        foreach (var levelData in levelButtons)
+        {
+            if (levelData.levelButton == null)
+            {
+                continue;
+            }
+
+            // All levels are always unlocked - keep buttons clickable
+            Button button = levelData.levelButton.GetComponent<Button>();
+            if (button != null)
+            {
+                button.interactable = true; // Always enable buttons
+            }
+
+            // Update time display (show for all levels)
+            UpdateTimeDisplay(levelData, true);
+
+            // Hide locked status display (all levels unlocked)
+            UpdateLockedDisplay(levelData, true);
+        }
+    }
+
+    private void UpdateTimeDisplay(LevelButtonData levelData, bool isUnlocked)
+    {
+        // Always show time display (all levels are unlocked)
+        // Get best time for this level
+        float bestTime = -1f;
+        if (ProgressManager.Instance != null)
+        {
+            bestTime = ProgressManager.Instance.GetLevelBestTime(levelData.levelIndex);
+        }
+
+        string timeString = bestTime > 0 ? ProgressManager.FormatTime(bestTime) : noTimeText;
+
+        // Try to update Text component
+        if (levelData.timeText != null)
+        {
+            levelData.timeText.text = timeString;
+        }
+        else if (levelData.timeTextTMP != null)
+        {
+            levelData.timeTextTMP.text = timeString;
+        }
+        else
+        {
+            // Try to find Text or TextMeshProUGUI in children
+            Text foundText = levelData.levelButton.GetComponentInChildren<Text>();
+            if (foundText != null)
+            {
+                foundText.text = timeString;
+            }
+            else
+            {
+                TextMeshProUGUI foundTMP = levelData.levelButton.GetComponentInChildren<TextMeshProUGUI>();
+                if (foundTMP != null)
+                {
+                    foundTMP.text = timeString;
+                }
+            }
+        }
+    }
+
+    private void UpdateLockedDisplay(LevelButtonData levelData, bool isUnlocked)
+    {
+        if (isUnlocked)
+        {
+            // Hide locked text if level is unlocked
+            if (levelData.lockedText != null)
+            {
+                levelData.lockedText.gameObject.SetActive(false);
+            }
+            if (levelData.lockedTextTMP != null)
+            {
+                levelData.lockedTextTMP.gameObject.SetActive(false);
+            }
+        }
+        else
+        {
+            // Show locked text if level is locked
+            if (levelData.lockedText != null)
+            {
+                levelData.lockedText.text = lockedText;
+                levelData.lockedText.gameObject.SetActive(true);
+            }
+            else if (levelData.lockedTextTMP != null)
+            {
+                levelData.lockedTextTMP.text = lockedText;
+                levelData.lockedTextTMP.gameObject.SetActive(true);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Call this method to refresh displays (useful when returning to Levels scene)
+    /// </summary>
+    public void RefreshDisplays()
+    {
+        UpdateLevelDisplays();
+    }
+}
+

--- a/Assets/Scripts/LevelProgressUI.cs.meta
+++ b/Assets/Scripts/LevelProgressUI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 994676ae1c254c340bfb5880cfeff41d

--- a/Assets/Scripts/LevelTimer.cs
+++ b/Assets/Scripts/LevelTimer.cs
@@ -1,0 +1,77 @@
+using UnityEngine;
+
+/// <summary>
+/// Tracks the time elapsed since the level started.
+/// Used to calculate completion time for saving best times.
+/// </summary>
+public class LevelTimer : MonoBehaviour
+{
+    private float levelStartTime;
+    private bool isTimerRunning = false;
+    private int currentLevelIndex;
+
+    private void Start()
+    {
+        StartTimer();
+    }
+
+    /// <summary>
+    /// Starts the timer when level begins
+    /// </summary>
+    public void StartTimer()
+    {
+        levelStartTime = Time.time;
+        isTimerRunning = true;
+        currentLevelIndex = UnityEngine.SceneManagement.SceneManager.GetActiveScene().buildIndex;
+        Debug.Log($"Level {currentLevelIndex} timer started");
+    }
+
+    /// <summary>
+    /// Stops the timer and returns the elapsed time
+    /// </summary>
+    /// <returns>Time elapsed in seconds</returns>
+    public float StopTimer()
+    {
+        if (!isTimerRunning)
+        {
+            Debug.LogWarning("Timer was not running!");
+            return 0f;
+        }
+
+        float elapsedTime = Time.time - levelStartTime;
+        isTimerRunning = false;
+        Debug.Log($"Level {currentLevelIndex} completed in {elapsedTime:F2} seconds");
+        return elapsedTime;
+    }
+
+    /// <summary>
+    /// Gets the current elapsed time without stopping the timer
+    /// </summary>
+    /// <returns>Time elapsed in seconds</returns>
+    public float GetCurrentTime()
+    {
+        if (!isTimerRunning)
+        {
+            return 0f;
+        }
+        return Time.time - levelStartTime;
+    }
+
+    /// <summary>
+    /// Checks if the timer is currently running
+    /// </summary>
+    public bool IsRunning()
+    {
+        return isTimerRunning;
+    }
+
+    /// <summary>
+    /// Resets the timer (useful for restarting a level)
+    /// </summary>
+    public void ResetTimer()
+    {
+        levelStartTime = Time.time;
+        Debug.Log($"Level {currentLevelIndex} timer reset");
+    }
+}
+

--- a/Assets/Scripts/LevelTimer.cs.meta
+++ b/Assets/Scripts/LevelTimer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3e41c49b980cf164789490f753b95d94

--- a/Assets/Scripts/ProgressManager.cs
+++ b/Assets/Scripts/ProgressManager.cs
@@ -1,0 +1,219 @@
+using UnityEngine;
+using System.Collections.Generic;
+
+/// <summary>
+/// Singleton manager for saving and loading player progress.
+/// Handles high scores (best times per level) and unlocked levels.
+/// Uses PlayerPrefs for data persistence.
+/// </summary>
+public class ProgressManager : MonoBehaviour
+{
+    private const string HIGH_SCORE_KEY = "HighScore";
+    private const string LEVEL_TIME_PREFIX = "LevelTime_";
+    private const string LEVEL_UNLOCKED_PREFIX = "LevelUnlocked_";
+    private const string DATA_VERSION_KEY = "ProgressDataVersion";
+    private const int CURRENT_DATA_VERSION = 1;
+
+    public static ProgressManager Instance { get; private set; }
+
+    private Dictionary<int, float> levelBestTimes;
+    private Dictionary<int, bool> levelUnlocked;
+    private float overallHighScore;
+
+    private void Awake()
+    {
+        if (Instance == null)
+        {
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+            LoadProgress();
+        }
+        else
+        {
+            Destroy(gameObject);
+        }
+    }
+
+    /// <summary>
+    /// Loads all saved progress from PlayerPrefs
+    /// </summary>
+    public void LoadProgress()
+    {
+        levelBestTimes = new Dictionary<int, float>();
+        levelUnlocked = new Dictionary<int, bool>();
+
+        // Check data version for future migration support
+        int savedVersion = PlayerPrefs.GetInt(DATA_VERSION_KEY, 0);
+        if (savedVersion != CURRENT_DATA_VERSION)
+        {
+            Debug.Log($"Progress data version mismatch. Current: {CURRENT_DATA_VERSION}, Saved: {savedVersion}");
+        }
+
+        // Load overall high score (best time across all levels)
+        overallHighScore = PlayerPrefs.GetFloat(HIGH_SCORE_KEY, 0f);
+
+        // Load level-specific data
+        // We'll check for levels 1-10 (adjust range as needed)
+        for (int levelIndex = 1; levelIndex <= 10; levelIndex++)
+        {
+            string timeKey = LEVEL_TIME_PREFIX + levelIndex;
+            string unlockKey = LEVEL_UNLOCKED_PREFIX + levelIndex;
+
+            if (PlayerPrefs.HasKey(timeKey))
+            {
+                float bestTime = PlayerPrefs.GetFloat(timeKey, float.MaxValue);
+                if (bestTime < float.MaxValue)
+                {
+                    levelBestTimes[levelIndex] = bestTime;
+                }
+            }
+
+            // Level 1 is always unlocked by default
+            if (levelIndex == 1)
+            {
+                levelUnlocked[levelIndex] = true;
+            }
+            else
+            {
+                levelUnlocked[levelIndex] = PlayerPrefs.GetInt(unlockKey, 0) == 1;
+            }
+        }
+
+        Debug.Log("Progress loaded successfully");
+    }
+
+    /// <summary>
+    /// Saves completion time for a level. Only saves if it's a new best time.
+    /// </summary>
+    /// <param name="levelIndex">Build index of the level scene</param>
+    /// <param name="completionTime">Time taken to complete the level in seconds</param>
+    public void SaveLevelTime(int levelIndex, float completionTime)
+    {
+        if (completionTime <= 0)
+        {
+            Debug.LogWarning($"Invalid completion time: {completionTime} for level {levelIndex}");
+            return;
+        }
+
+        string timeKey = LEVEL_TIME_PREFIX + levelIndex;
+        bool isNewBest = false;
+
+        // Check if this is a new best time
+        if (levelBestTimes.ContainsKey(levelIndex))
+        {
+            if (completionTime < levelBestTimes[levelIndex])
+            {
+                isNewBest = true;
+                levelBestTimes[levelIndex] = completionTime;
+            }
+        }
+        else
+        {
+            // First completion of this level
+            isNewBest = true;
+            levelBestTimes[levelIndex] = completionTime;
+        }
+
+        if (isNewBest)
+        {
+            PlayerPrefs.SetFloat(timeKey, completionTime);
+            PlayerPrefs.Save();
+
+            // Update overall high score if this is the best time across all levels
+            if (overallHighScore == 0f || completionTime < overallHighScore)
+            {
+                overallHighScore = completionTime;
+                PlayerPrefs.SetFloat(HIGH_SCORE_KEY, overallHighScore);
+                PlayerPrefs.Save();
+            }
+
+            Debug.Log($"New best time for Level {levelIndex}: {completionTime:F2}s");
+        }
+    }
+
+    /// <summary>
+    /// Gets the best time for a specific level
+    /// </summary>
+    /// <param name="levelIndex">Build index of the level scene</param>
+    /// <returns>Best time in seconds, or -1 if level hasn't been completed</returns>
+    public float GetLevelBestTime(int levelIndex)
+    {
+        if (levelBestTimes.ContainsKey(levelIndex))
+        {
+            return levelBestTimes[levelIndex];
+        }
+        return -1f; // Level not completed yet
+    }
+
+    /// <summary>
+    /// Gets the overall high score (best time across all levels)
+    /// </summary>
+    /// <returns>Best time in seconds, or 0 if no levels completed</returns>
+    public float GetHighScore()
+    {
+        return overallHighScore;
+    }
+
+    /// <summary>
+    /// Unlocks a level
+    /// </summary>
+    /// <param name="levelIndex">Build index of the level scene</param>
+    public void UnlockLevel(int levelIndex)
+    {
+        if (!levelUnlocked.ContainsKey(levelIndex) || !levelUnlocked[levelIndex])
+        {
+            levelUnlocked[levelIndex] = true;
+            string unlockKey = LEVEL_UNLOCKED_PREFIX + levelIndex;
+            PlayerPrefs.SetInt(unlockKey, 1);
+            PlayerPrefs.Save();
+            Debug.Log($"Level {levelIndex} unlocked!");
+        }
+    }
+
+    /// <summary>
+    /// Checks if a level is unlocked
+    /// All levels are always unlocked (no restrictions)
+    /// </summary>
+    /// <param name="levelIndex">Build index of the level scene</param>
+    /// <returns>Always returns true (all levels unlocked)</returns>
+    public bool IsLevelUnlocked(int levelIndex)
+    {
+        // All levels are always unlocked - no restrictions
+        return true;
+    }
+
+    /// <summary>
+    /// Formats time in seconds to a readable string (MM:SS.ms)
+    /// </summary>
+    public static string FormatTime(float timeInSeconds)
+    {
+        if (timeInSeconds < 0)
+        {
+            return "N/A";
+        }
+
+        int minutes = Mathf.FloorToInt(timeInSeconds / 60f);
+        int seconds = Mathf.FloorToInt(timeInSeconds % 60f);
+        int milliseconds = Mathf.FloorToInt((timeInSeconds * 100f) % 100f);
+
+        return string.Format("{0:00}:{1:00}.{2:00}", minutes, seconds, milliseconds);
+    }
+
+    /// <summary>
+    /// Resets all progress (for testing/debugging)
+    /// </summary>
+    public void ResetProgress()
+    {
+        PlayerPrefs.DeleteAll();
+        levelBestTimes.Clear();
+        levelUnlocked.Clear();
+        overallHighScore = 0f;
+        Debug.Log("All progress has been reset");
+    }
+
+    private void OnApplicationQuit()
+    {
+        PlayerPrefs.Save();
+    }
+}
+

--- a/Assets/Scripts/ProgressManager.cs.meta
+++ b/Assets/Scripts/ProgressManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3fd64221e127e2649a725f064d77406a


### PR DESCRIPTION
## Description

> This pull request introduces a **Player Progress Saving System with Level Time Tracking**, allowing players to track and preserve their performance across play sessions for a more engaging and rewarding experience.  
>  
> Key updates include:  
> - Added **Level Timer** to record completion times for each level  
> - Implemented **Progress Manager** to save best times and high scores using PlayerPrefs  
> - Added **Level Progress UI** to display best times for all levels  
> - Updated **EndLineTrigger** to save new best times upon level completion  
> - Enhanced **Main Menu** to show overall high score and persist it across sessions  
> - All levels are always accessible — no unlock restrictions  

## Semver Changes

- [ ] Patch (bug fix, no new features)  
- [x] Minor (new features, no breaking changes)  
- [ ] Major (breaking changes)  

## Issues

> #19 

## Checklist

- [x] I have read the [Contributing Guidelines](../Contributor_Guide/Contruting.md).  
