### PR TITLE
feat: added idle animation

### DIFF
--- a/Assets/Scenes/Level1.unity
+++ b/Assets/Scenes/Level1.unity
@@ -2823,8 +2823,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 330585543}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.20314598, y: -0.0010157359, z: 0.00021073695, w: 0.9791479}
-  m_LocalPosition: {x: -22.72, y: 2.3520002, z: -21.24}
+  m_LocalRotation: {x: 0.20314601, y: -0.0010157359, z: 0.00021073698, w: 0.9791479}
+  m_LocalPosition: {x: -22.72, y: 2.461, z: -34.82}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -6137,7 +6137,7 @@ Transform:
   m_GameObject: {fileID: 613601990}
   serializedVersion: 2
   m_LocalRotation: {x: 0.20314598, y: -0.0010157359, z: 0.00021073695, w: 0.9791479}
-  m_LocalPosition: {x: -22.72, y: 2.3520002, z: -21.24}
+  m_LocalPosition: {x: -22.72, y: 2.461, z: -34.82}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -12616,6 +12616,7 @@ GameObject:
   - component: {fileID: 1166695322}
   - component: {fileID: 1166695323}
   - component: {fileID: 1166695324}
+  - component: {fileID: 1166695325}
   m_Layer: 0
   m_Name: Player
   m_TagString: Player
@@ -12727,7 +12728,7 @@ Transform:
   m_GameObject: {fileID: 1166695311}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -1.4551915e-11, w: 1}
-  m_LocalPosition: {x: -22.73, y: 0.26200032, z: -16.42}
+  m_LocalPosition: {x: -22.73, y: 0.371, z: -30}
   m_LocalScale: {x: 1, y: 0.45452, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -12742,7 +12743,7 @@ Rigidbody:
   m_GameObject: {fileID: 1166695311}
   serializedVersion: 4
   m_Mass: 1
-  m_Drag: 0
+  m_Drag: 4
   m_AngularDrag: 0.05
   m_CenterOfMass: {x: 0, y: 0, z: 0}
   m_InertiaTensor: {x: 1, y: 1, z: 1}
@@ -12998,6 +12999,21 @@ MonoBehaviour:
   cubeMesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
   sphereMesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
   capsuleMesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &1166695325
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1166695311}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5c2b194ef392c664cb5248fd0f28b9d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  pulseAmount: 0.1
+  pulseSpeed: 2
+  rotateSpeed: 20
 --- !u!1 &1177075428
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Level2.unity
+++ b/Assets/Scenes/Level2.unity
@@ -6910,7 +6910,7 @@ Transform:
   m_GameObject: {fileID: 827671623}
   serializedVersion: 2
   m_LocalRotation: {x: 0.20314598, y: -0.0010157359, z: 0.00021073695, w: 0.9791479}
-  m_LocalPosition: {x: -19.84, y: 2.3899999, z: -38.6}
+  m_LocalPosition: {x: -19.84, y: 2.449, z: -38.6}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -7905,6 +7905,7 @@ GameObject:
   - component: {fileID: 945966556}
   - component: {fileID: 945966557}
   - component: {fileID: 945966558}
+  - component: {fileID: 945966559}
   m_Layer: 0
   m_Name: Player
   m_TagString: Player
@@ -7921,7 +7922,7 @@ Rigidbody:
   m_GameObject: {fileID: 945966544}
   serializedVersion: 4
   m_Mass: 1
-  m_Drag: 0
+  m_Drag: 4
   m_AngularDrag: 0.05
   m_CenterOfMass: {x: 0, y: 0, z: 0}
   m_InertiaTensor: {x: 1, y: 1, z: 1}
@@ -8043,7 +8044,7 @@ Transform:
   m_GameObject: {fileID: 945966544}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -19.85, y: 0.3, z: -33.78}
+  m_LocalPosition: {x: -19.85, y: 0.359, z: -33.78}
   m_LocalScale: {x: 1, y: 0.45452, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -8287,6 +8288,21 @@ MonoBehaviour:
   cubeMesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
   sphereMesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
   capsuleMesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &945966559
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 945966544}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5c2b194ef392c664cb5248fd0f28b9d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  pulseAmount: 0.1
+  pulseSpeed: 2
+  rotateSpeed: 20
 --- !u!1 &948847381
 GameObject:
   m_ObjectHideFlags: 0
@@ -13140,7 +13156,7 @@ Transform:
   m_GameObject: {fileID: 1518226789}
   serializedVersion: 2
   m_LocalRotation: {x: 0.203146, y: -0.0010157526, z: 0.00021073967, w: 0.9791479}
-  m_LocalPosition: {x: -19.84, y: 2.3899999, z: -38.6}
+  m_LocalPosition: {x: -19.84, y: 2.449, z: -38.6}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Scenes/Level3.unity
+++ b/Assets/Scenes/Level3.unity
@@ -4765,7 +4765,7 @@ Transform:
   m_GameObject: {fileID: 513477635}
   serializedVersion: 2
   m_LocalRotation: {x: 0.20314598, y: -0.001015736, z: 0.000210737, w: 0.9791479}
-  m_LocalPosition: {x: -19.84, y: 2.35, z: -38.6}
+  m_LocalPosition: {x: -19.84, y: 2.4229999, z: -38.6}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -7980,7 +7980,7 @@ Transform:
   m_GameObject: {fileID: 818031441}
   serializedVersion: 2
   m_LocalRotation: {x: 0.20314598, y: -0.0010157359, z: 0.00021073695, w: 0.9791479}
-  m_LocalPosition: {x: -19.84, y: 2.35, z: -38.6}
+  m_LocalPosition: {x: -19.84, y: 2.4229999, z: -38.6}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -14862,6 +14862,7 @@ GameObject:
   - component: {fileID: 1843940780}
   - component: {fileID: 1843940781}
   - component: {fileID: 1843940782}
+  - component: {fileID: 1843940783}
   m_Layer: 0
   m_Name: Player
   m_TagString: Player
@@ -14892,7 +14893,7 @@ Rigidbody:
   m_GameObject: {fileID: 1843940769}
   serializedVersion: 4
   m_Mass: 1
-  m_Drag: 0
+  m_Drag: 4
   m_AngularDrag: 0.05
   m_CenterOfMass: {x: 0, y: 0, z: 0}
   m_InertiaTensor: {x: 1, y: 1, z: 1}
@@ -15014,7 +15015,7 @@ Transform:
   m_GameObject: {fileID: 1843940769}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -19.85, y: 0.26, z: -33.78}
+  m_LocalPosition: {x: -19.85, y: 0.333, z: -33.78}
   m_LocalScale: {x: 1, y: 0.45452, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -15244,6 +15245,21 @@ MonoBehaviour:
   cubeMesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
   sphereMesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
   capsuleMesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &1843940783
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1843940769}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5c2b194ef392c664cb5248fd0f28b9d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  pulseAmount: 0.1
+  pulseSpeed: 2
+  rotateSpeed: 20
 --- !u!1 &1861152422
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Level4.unity
+++ b/Assets/Scenes/Level4.unity
@@ -4423,6 +4423,7 @@ GameObject:
   - component: {fileID: 1106560897}
   - component: {fileID: 1106560898}
   - component: {fileID: 1106560899}
+  - component: {fileID: 1106560900}
   m_Layer: 0
   m_Name: Player
   m_TagString: Player
@@ -4795,6 +4796,19 @@ MonoBehaviour:
   cubeMesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
   sphereMesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
   capsuleMesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &1106560900
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1106560884}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b8786dd1618832e4ba35a2fdb3f0cb0b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  rotateSpeed: 20
 --- !u!1 &1110252937
 GameObject:
   m_ObjectHideFlags: 0
@@ -6779,17 +6793,6 @@ MonoBehaviour:
   m_LightCookieSize: {x: 1, y: 1}
   m_LightCookieOffset: {x: 0, y: 0}
   m_SoftShadowQuality: 0
-  m_RenderingLayersMask:
-    serializedVersion: 0
-    m_Bits: 1
-  m_ShadowRenderingLayersMask:
-    serializedVersion: 0
-    m_Bits: 1
-  m_Version: 4
-  m_LightLayerMask: 1
-  m_ShadowLayerMask: 1
-  m_RenderingLayers: 1
-  m_ShadowRenderingLayers: 1
 --- !u!1 &1560446382
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Level6.unity
+++ b/Assets/Scenes/Level6.unity
@@ -2066,6 +2066,7 @@ GameObject:
   - component: {fileID: 1106560896}
   - component: {fileID: 1106560897}
   - component: {fileID: 1106560898}
+  - component: {fileID: 1106560899}
   m_Layer: 0
   m_Name: Player
   m_TagString: Player
@@ -2423,6 +2424,19 @@ MonoBehaviour:
   cubeMesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
   sphereMesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
   capsuleMesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &1106560899
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1106560884}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b8786dd1618832e4ba35a2fdb3f0cb0b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  rotateSpeed: 20
 --- !u!1 &1134948137
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Level7.unity
+++ b/Assets/Scenes/Level7.unity
@@ -4655,7 +4655,7 @@ Transform:
   m_GameObject: {fileID: 452507388}
   serializedVersion: 2
   m_LocalRotation: {x: 0.20314598, y: -0.0010157359, z: 0.00021073695, w: 0.9791479}
-  m_LocalPosition: {x: -19.84, y: 2.3899999, z: -38.6}
+  m_LocalPosition: {x: -19.84, y: 2.431, z: -38.6}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -7932,6 +7932,7 @@ GameObject:
   - component: {fileID: 945966556}
   - component: {fileID: 945966557}
   - component: {fileID: 945966558}
+  - component: {fileID: 945966559}
   m_Layer: 0
   m_Name: Player
   m_TagString: Player
@@ -8070,7 +8071,7 @@ Transform:
   m_GameObject: {fileID: 945966544}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -19.85, y: 0.3, z: -33.78}
+  m_LocalPosition: {x: -19.85, y: 0.336, z: -33.78}
   m_LocalScale: {x: 1, y: 0.45452, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -8314,6 +8315,21 @@ MonoBehaviour:
   cubeMesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
   sphereMesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
   capsuleMesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &945966559
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 945966544}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5c2b194ef392c664cb5248fd0f28b9d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  pulseAmount: 0.1
+  pulseSpeed: 2
+  rotateSpeed: 20
 --- !u!1 &948847381
 GameObject:
   m_ObjectHideFlags: 0
@@ -10047,7 +10063,7 @@ Transform:
   m_GameObject: {fileID: 1135091756}
   serializedVersion: 2
   m_LocalRotation: {x: 0.20314598, y: -0.0010157359, z: 0.00021073695, w: 0.9791479}
-  m_LocalPosition: {x: -19.84, y: 2.3899999, z: -38.6}
+  m_LocalPosition: {x: -19.84, y: 2.4259999, z: -38.6}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Scripts/PlayerIdleRotate.cs
+++ b/Assets/Scripts/PlayerIdleRotate.cs
@@ -1,0 +1,38 @@
+using UnityEngine;
+
+public class PlayerIdleAnimate : MonoBehaviour
+{
+    public float pulseAmount = 0.1f;
+    public float pulseSpeed = 2f;
+    public float rotateSpeed = 20f;
+
+    private Vector3 originalScale;
+
+    void Start()
+    {
+        originalScale = transform.localScale;
+    }
+
+    void Update()
+    {
+        bool isMoving = Input.GetKey(KeyCode.W) ||
+                        Input.GetKey(KeyCode.A) ||
+                        Input.GetKey(KeyCode.S) ||
+                        Input.GetKey(KeyCode.D) ||
+                        Input.GetKey(KeyCode.UpArrow) ||
+                        Input.GetKey(KeyCode.DownArrow) ||
+                        Input.GetKey(KeyCode.LeftArrow) ||
+                        Input.GetKey(KeyCode.RightArrow);
+
+        if (!isMoving)
+        {
+            float scaleOffset = Mathf.Sin(Time.time * pulseSpeed) * pulseAmount;
+            transform.localScale = originalScale + Vector3.one * scaleOffset;
+            transform.Rotate(Vector3.up * rotateSpeed * Time.deltaTime);
+        }
+        else
+        {
+            transform.localScale = originalScale;
+        }
+    }
+}

--- a/Assets/Scripts/PlayerIdleRotate.cs.meta
+++ b/Assets/Scripts/PlayerIdleRotate.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5c2b194ef392c664cb5248fd0f28b9d3

--- a/Assets/Scripts/PlayerIdleRotateOnly.cs
+++ b/Assets/Scripts/PlayerIdleRotateOnly.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+
+public class PlayerIdleRotateOnly : MonoBehaviour
+{
+    public float rotateSpeed = 20f;
+
+    void Update()
+    {
+        bool isMoving = Input.GetKey(KeyCode.W) ||
+                        Input.GetKey(KeyCode.A) ||
+                        Input.GetKey(KeyCode.S) ||
+                        Input.GetKey(KeyCode.D) ||
+                        Input.GetKey(KeyCode.UpArrow) ||
+                        Input.GetKey(KeyCode.DownArrow) ||
+                        Input.GetKey(KeyCode.LeftArrow) ||
+                        Input.GetKey(KeyCode.RightArrow);
+        if (!isMoving)
+        {
+            transform.Rotate(Vector3.up * rotateSpeed * Time.deltaTime);
+        }
+    }
+}

--- a/Assets/Scripts/PlayerIdleRotateOnly.cs.meta
+++ b/Assets/Scripts/PlayerIdleRotateOnly.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b8786dd1618832e4ba35a2fdb3f0cb0b


### PR DESCRIPTION
## Description

> Implemented an idle animation for the player as requested in the issue.  
> The core requirement — **slow rotation when the player is idle** — has been added.  
> Additionally, a subtle **breathing (scale-pulse) animation** was included to improve visual clarity for spherical and capsule shapes, where rotation alone is not visible.  
> This combined idle animation enhances player feedback while maintaining the original behavior requirement.

## Semver Changes

- [ ] Patch (bug fix, no new features)
- [x] Minor (new features, no breaking changes)
- [ ] Major (breaking changes)

## Issues

> Closes #99 (Add idle animation)

## Checklist

- [x] I have read the [Contributing Guidelines](../Contributor_Guide/Contruting.md).
